### PR TITLE
added mkdirs() to the output to create needed folders

### DIFF
--- a/src/main/java/au/csiro/fhir/claml/FhirClamlService.java
+++ b/src/main/java/au/csiro/fhir/claml/FhirClamlService.java
@@ -280,6 +280,7 @@ public class FhirClamlService {
 
             cs.setCount(count);
 
+            output.getParentFile().mkdirs();
             context.newJsonParser().encodeResourceToWriter(cs, new FileWriter(output));
 
 


### PR DESCRIPTION
added mkdirs() to the output to create needed folders if there aren't existing.
Before there was a FileNotFoundException thrown if the folder wasn't created beforehand.