### PR TITLE
add versionNeeded flag

### DIFF
--- a/src/main/java/au/csiro/fhir/claml/Application.java
+++ b/src/main/java/au/csiro/fhir/claml/Application.java
@@ -120,6 +120,9 @@ public class Application implements CommandLineRunner {
 
 		options.addOption("valueset", true, "The value set that represents the entire code system.");
 
+		options.addOption("versionNeeded", false, "Flag to indicate if the code system commits "
+				+ "to concept permanence across versions.");
+
 		// The following options are not yet supported
 		/*
 
@@ -160,9 +163,6 @@ public class Application implements CommandLineRunner {
 	    options.addOption("v", "version", true, "Business version. If this option is not specified "
 	        + "then the ClaML title.version attribute value will be used.");
 
-	    options.addOption("versionNeeded", false, "Flag to indicate if the code system commits "
-	        + "to concept permanence across versions.");
-
 		 */
 
 
@@ -190,6 +190,7 @@ public class Application implements CommandLineRunner {
 						line.getOptionValue("url"),
 						line.getOptionValue("valueSet"),
 						line.getOptionValue("content"),
+						line.hasOption("versionNeeded"),
 						new File(line.getOptionValue("output")));
 			} catch (Throwable t) {
 				System.out.println("There was a problem transforming the ClaML file into FHIR: " 

--- a/src/main/java/au/csiro/fhir/claml/FhirClamlService.java
+++ b/src/main/java/au/csiro/fhir/claml/FhirClamlService.java
@@ -68,17 +68,18 @@ public class FhirClamlService {
     private static final Logger log = LoggerFactory.getLogger(FhirClamlService.class);
 
     String claml2fhir(File clamlFile,
-            List<String> displayRubrics,
-            String definitionRubric,
-            List<String> designationRubrics,
-            List<String> excludeClassKind,
-            Boolean excludeKindlessClasses,
-            String hierarchyMeaning,
-            String id,
-            String url,
-            String valueSet,
-            String content,
-            File output) throws DataFormatException, IOException, ParserConfigurationException, SAXException {
+                      List<String> displayRubrics,
+                      String definitionRubric,
+                      List<String> designationRubrics,
+                      List<String> excludeClassKind,
+                      Boolean excludeKindlessClasses,
+                      String hierarchyMeaning,
+                      String id,
+                      String url,
+                      String valueSet,
+                      String content,
+                      boolean versionNeeded,
+                      File output) throws DataFormatException, IOException, ParserConfigurationException, SAXException {
 
     	// Default values
     	if (displayRubrics == null || displayRubrics.isEmpty()) {
@@ -147,6 +148,7 @@ public class FhirClamlService {
 			for  (Identifier ident : claml.getIdentifier()) {
                 cs.addIdentifier(new org.hl7.fhir.r4.model.Identifier().setSystem(ident.getAuthority()).setValue(ident.getUid()));
             }
+            cs.setVersionNeeded(versionNeeded);
 
             Title title = claml.getTitle();
             if (title != null) {


### PR DESCRIPTION
This PR adds the ability to set the `versionNeeded` boolean flag to the generated resource, which should be used for code systems like ICD-10 (-WHO/-GM/-CM), which does not commit to concept permanence between releases.