### PR TITLE
Update FhirClamlService.java to convert claml-meta to fhir-property

### DIFF
--- a/src/main/java/au/csiro/fhir/claml/FhirClamlService.java
+++ b/src/main/java/au/csiro/fhir/claml/FhirClamlService.java
@@ -217,6 +217,9 @@ public class FhirClamlService {
                 for (SuperClass sup : c.getSuperClass()) {
                     concept.addProperty().setCode("parent").setValue(new CodeType(sup.getCode()));
                 }
+		for (Meta meta : c.getMeta()) {
+                    concept.addProperty().setCode(meta.getName()).setValue(new StringType(meta.getValue()));
+                }
                 Map<String,List<Rubric>> displayRubricValues = new HashMap<>();
                 for (Rubric rubric : c.getRubric()) {
                     Object kind = rubric.getKind();


### PR DESCRIPTION
In some Claml files the meta tag is used for any additional information per concept. Converting these to a property with the claml-name as fhir-code and claml-value as a fixed fhir-valueString.