### PR TITLE
Modifiers

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ java -jar fhir-claml-0.0.1-SNAPSHOT.jar -i icd10gm2020syst_claml_20190920.xml -d
 
 ### Known Issues
 
-* Modifiers are not currently supported
+* Inherited modifiers are not currently supported
 
 * In some Linux environments (including docker deployments), you may need to install some packages to properly support UTF-8 encodings. Andreas Streichardt provided these commands for inclusion in a Dockerfile to fix this (these can be adapted to Linux commands if you need):
 ```RUN apt-get update && apt-get install -y python3 git openjdk-11-jdk maven jq unzip locales

--- a/src/main/java/au/csiro/fhir/claml/FhirClamlService.java
+++ b/src/main/java/au/csiro/fhir/claml/FhirClamlService.java
@@ -8,8 +8,11 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import javax.xml.bind.JAXBContext;
 import javax.xml.bind.JAXBException;
@@ -46,6 +49,10 @@ import au.csiro.fhir.claml.model.claml.Fragment;
 import au.csiro.fhir.claml.model.claml.Identifier;
 import au.csiro.fhir.claml.model.claml.Label;
 import au.csiro.fhir.claml.model.claml.ListItem;
+import au.csiro.fhir.claml.model.claml.Meta;
+import au.csiro.fhir.claml.model.claml.ModifiedBy;
+import au.csiro.fhir.claml.model.claml.Modifier;
+import au.csiro.fhir.claml.model.claml.ModifierClass;
 import au.csiro.fhir.claml.model.claml.Para;
 import au.csiro.fhir.claml.model.claml.Reference;
 import au.csiro.fhir.claml.model.claml.Rubric;
@@ -119,191 +126,8 @@ public class FhirClamlService {
             Unmarshaller jaxbUnmarshaller = jaxbContext.createUnmarshaller();
             ClaML claml = (ClaML) jaxbUnmarshaller.unmarshal(source);
 
-            CodeSystem cs = new CodeSystem();
-            cs.setStatus(PublicationStatus.DRAFT);
-            cs.setExperimental(true);
-            try {
-                cs.setContent(CodeSystemContentMode.fromCode(content));
-                cs.setHierarchyMeaning(CodeSystemHierarchyMeaning.fromCode(hierarchyMeaning));
-            } catch (FHIRException e) {
-                // TODO Auto-generated catch block
-                e.printStackTrace();
-            }  //TODO
-
-            if (id != null) {
-                cs.setId(id);
-            }
-
-            if (url != null) {
-                cs.setUrl(url);
-            }
-
-            if (valueSet != null) {
-                cs.setValueSet(valueSet);
-            }
-
-            if (claml.getIdentifier().size() > 1) {
-                log.warn("Multiple identifiers not currently supported by FHIR Code Systems");
-            }
-			for  (Identifier ident : claml.getIdentifier()) {
-                cs.addIdentifier(new org.hl7.fhir.r4.model.Identifier().setSystem(ident.getAuthority()).setValue(ident.getUid()));
-            }
-            cs.setVersionNeeded(versionNeeded);
-
-            Title title = claml.getTitle();
-            if (title != null) {
-                if (title.getVersion() != null) {
-                    cs.setVersion(title.getVersion());
-                }
-                if (title.getName() != null) {
-                    cs.setName(title.getName());
-                    cs.setDescription(title.getContent());
-                } else {
-                    cs.setName(title.getContent());
-                    cs.setDescription(title.getContent());
-                }
-//                if (title.getDate() != null) {
-//                    try {
-//                        cs.setDate(DateFormat.getDateInstance().parse(title.getDate()));
-//                    } catch (ParseException e) {
-//                        e.printStackTrace();
-//                    }
-//                }
-            }
-
-            cs.addProperty().setCode("kind").setType(PropertyType.CODE);
-            for (RubricKind rk : claml.getRubricKinds().getRubricKind()) {
-                if (! definitionRubric.equals(rk.getName()) &&
-                        !displayRubrics.contains(rk.getName()) &&
-                        !designationRubrics.contains(rk.getName())) {
-                    PropertyComponent p = cs.addProperty();
-                    p.setCode(rk.getName());
-                    p.setType(PropertyType.STRING);
-                    if (rk.getDisplay() != null && !rk.getDisplay().isEmpty()) {
-                        if (rk.getDisplay().size() > 1) {
-                            log.warn("Found more than one display for rubric kind " + rk.getName() + ": ignoring additional displays");
-                        }
-                        p.setDescription(rk.getDisplay().get(0).getContent());
-                    }
-                    //TODO filters?
-                }
-                if (rk.isInherited()) {
-                    log.warn("Inherited rubric kinds are not fully supported: " + rk.getName());
-                }
-            }
-
-            int count = 0;
-
-            for (Class c : claml.getClazz()) {
-                if (c.getKind() != null && excludeClassKind.contains(getClassKindName(c.getKind()))) {
-                    log.info("Concept " + c.getCode() + " has excluded kind " + getClassKindName(c.getKind()) + ": skipping");
-                    continue;
-                }
-                ConceptDefinitionComponent concept = cs.addConcept().setCode(c.getCode());
-                count++;
-                if (c.getKind() != null) {
-                    if (getClassKindName(c.getKind()) != null) {
-                        concept.addProperty().setCode("kind").setValue(new CodeType(getClassKindName(c.getKind())));
-                   } else {
-                        log.warn("Unrecognised class kind on class " + c.getCode() + ": " + c.getKind());
-                    }
-                } else if (excludeKindlessClasses) {
-                    log.info("Concept " + c.getCode() + " has excluded kind " + getClassKindName(c.getKind()) + ": skipping");
-                    continue;
-                } else {
-                    log.info("Concept " + c.getCode() + " has no kind.");
-                }
-                for (SubClass sub : c.getSubClass()) {
-                    concept.addProperty().setCode("child").setValue(new CodeType(sub.getCode()));
-                }
-                for (SuperClass sup : c.getSuperClass()) {
-                    concept.addProperty().setCode("parent").setValue(new CodeType(sup.getCode()));
-                }
-                Map<String,List<Rubric>> displayRubricValues = new HashMap<>();
-                for (Rubric rubric : c.getRubric()) {
-                    Object kind = rubric.getKind();
-                    if (kind instanceof RubricKind) {
-                        RubricKind rkind = (RubricKind) kind;
-                        if (displayRubrics.contains(rkind.getName())) {
-                            final String value;
-                            if (rubric.getLabel().size() > 1) {
-                                log.warn("Found more than one label on display rubric " + rkind.getName() + " for code " + c.getCode());
-                            }
-                            value = getLabelValue(rubric.getLabel().get(0));
-                            if (!displayRubricValues.containsKey(rkind.getName())) {
-                            	displayRubricValues.put(rkind.getName(), new ArrayList<>());
-                            }
-                            displayRubricValues.get(rkind.getName()).add(rubric);
-                        } else if (rkind.getName().equals(definitionRubric)) {
-                                final String value;
-                                if (rubric.getLabel().size() > 1) {
-                                    log.warn("Found more than one label on definition rubric for code " + c.getCode());
-                                }
-                                value = getLabelValue(rubric.getLabel().get(0));
-                                concept.setDefinition(value);
-
-                        } else if (designationRubrics.contains(rkind.getName())) {
-                            addDesignationsForRubric(concept, rubric);
-                        } else {
-                            for (Label l : rubric.getLabel()) {
-                                String v = getLabelValue(l);
-                                if (v != null && v.length() > 0) {
-                                    ConceptPropertyComponent prop = concept.addProperty();
-                                    prop.setCode(rkind.getName());
-                                    prop.setValue(new StringType(v));
-                                }
-                            }
-                        }
-                    } else {
-                        log.warn("Unexpected rubric kind " + kind);
-                    }
-                }
-                
-                for (String dr : displayRubrics) {
-                	if (!displayRubricValues.containsKey(dr)) {
-                		continue;
-                	}
-            		List<Rubric> values = displayRubricValues.get(dr);
-                	if (!concept.hasDisplay()) {
-                		if (values.size() > 1) {
-                			log.warn("Found multiple display rubrics " + dr + " for code " + c.getCode());
-                		}
-                		Rubric rubric = values.get(0);
-                        String value = getLabelValue(rubric.getLabel().get(0));
-
-                		concept.setDisplay(value);
-                		if (rubric.getLabel().size() > 1) {
-                			if (log.isWarnEnabled()) {
-                                log.warn("Found more than one label on display rubric " + dr + " for code " + c.getCode());
-                			}
-                			for (int i = 1; i < values.size(); i++) {
-                				addDesignationForLabel(concept, rubric, (RubricKind) rubric.getKind(), rubric.getLabel().get(i));
-                			}
-                		}
-                	} else {
-                		// We've already got a display, dump everything else as a designation
-                		for (Rubric r : values) {
-                			addDesignationsForRubric(concept, r);
-                		}
-                	}
-                }
-
-                if (!concept.hasCode()) {
-                    log.warn("Concept " + concept + " has no code!");
-                } else {
-                    if (!concept.hasDisplay()) {
-                        log.warn("Concept " + concept.getCode() + " has no display text. Using code as display text");
-                        concept.setDisplay(concept.getCode());
-                        if (!concept.hasDefinition()) {
-                            concept.setDefinition(concept.getCode());
-                        }
-                    } else if (!concept.hasDefinition()) {
-                        concept.setDefinition(concept.getDisplay());
-                    }
-                }
-            }
-
-            cs.setCount(count);
+            CodeSystem cs = claml2FhirObject(claml, displayRubrics, definitionRubric, designationRubrics, excludeClassKind,
+                    excludeKindlessClasses, hierarchyMeaning, id, url, valueSet, content, versionNeeded);
 
             if (output.getParentFile() != null) {
             	output.getParentFile().mkdirs();
@@ -319,6 +143,320 @@ public class FhirClamlService {
 
         return "";
 
+    }
+
+    protected CodeSystem claml2FhirObject(ClaML claml, List<String> displayRubrics, String definitionRubric,
+            List<String> designationRubrics, List<String> excludeClassKind, Boolean excludeKindlessClasses,
+            String hierarchyMeaning, String id, String url, String valueSet, String content, boolean versionNeeded) {
+        CodeSystem cs = new CodeSystem();
+        cs.setStatus(PublicationStatus.DRAFT);
+        cs.setExperimental(true);
+        try {
+            cs.setContent(CodeSystemContentMode.fromCode(content));
+            cs.setHierarchyMeaning(CodeSystemHierarchyMeaning.fromCode(hierarchyMeaning));
+        } catch (FHIRException e) {
+            // TODO Auto-generated catch block
+            e.printStackTrace();
+        }  //TODO
+
+        if (id != null) {
+            cs.setId(id);
+        }
+
+        if (url != null) {
+            cs.setUrl(url);
+        }
+
+        if (valueSet != null) {
+            cs.setValueSet(valueSet);
+        }
+
+        if (claml.getIdentifier().size() > 1) {
+            log.warn("Multiple identifiers not currently supported by FHIR Code Systems");
+        }
+        for  (Identifier ident : claml.getIdentifier()) {
+            cs.addIdentifier(new org.hl7.fhir.r4.model.Identifier().setSystem(ident.getAuthority()).setValue(ident.getUid()));
+        }
+        cs.setVersionNeeded(versionNeeded);
+
+        Title title = claml.getTitle();
+        if (title != null) {
+            if (title.getVersion() != null) {
+                cs.setVersion(title.getVersion());
+            }
+            if (title.getName() != null) {
+                cs.setName(title.getName());
+                cs.setDescription(title.getContent());
+            } else {
+                cs.setName(title.getContent());
+                cs.setDescription(title.getContent());
+            }
+//                if (title.getDate() != null) {
+//                    try {
+//                        cs.setDate(DateFormat.getDateInstance().parse(title.getDate()));
+//                    } catch (ParseException e) {
+//                        e.printStackTrace();
+//                    }
+//                }
+        }
+
+        cs.addProperty().setCode("kind").setType(PropertyType.CODE);
+        for (RubricKind rk : claml.getRubricKinds().getRubricKind()) {
+            if (! definitionRubric.equals(rk.getName()) &&
+                    !displayRubrics.contains(rk.getName()) &&
+                    !designationRubrics.contains(rk.getName())) {
+                PropertyComponent p = cs.addProperty();
+                p.setCode(rk.getName());
+                p.setType(PropertyType.STRING);
+                if (rk.getDisplay() != null && !rk.getDisplay().isEmpty()) {
+                    if (rk.getDisplay().size() > 1) {
+                        log.warn("Found more than one display for rubric kind " + rk.getName() + ": ignoring additional displays");
+                    }
+                    p.setDescription(rk.getDisplay().get(0).getContent());
+                }
+                //TODO filters?
+            }
+            if (rk.isInherited()) {
+                log.warn("Inherited rubric kinds are not fully supported: " + rk.getName());
+            }
+        }
+
+        int count = 0;
+        
+        Map<String,ConceptDefinitionComponent> concepts = new HashMap<>();
+        Map<String,List<ModifiedBy>> modifiedBy = new HashMap<>();
+        Map<String,Set<String>> descendents = new HashMap<>();
+
+        for (Class c : claml.getClazz()) {
+            if (c.getKind() != null && excludeClassKind.contains(getClassKindName(c.getKind()))) {
+                log.info("Concept " + c.getCode() + " has excluded kind " + getClassKindName(c.getKind()) + ": skipping");
+                continue;
+            }
+            if (concepts.containsKey(c.getCode()) ) {
+                log.error("A concept already exists with code " + c);
+            }
+            ConceptDefinitionComponent concept = cs.addConcept().setCode(c.getCode());
+            concepts.put(c.getCode(), concept);
+            modifiedBy.put(c.getCode(),  new ArrayList<>());
+            if (!descendents.containsKey(c.getCode()) ) {
+                descendents.put(c.getCode(), new HashSet<>());
+            }
+            count++;
+            if (c.getKind() != null) {
+                if (getClassKindName(c.getKind()) != null) {
+                    concept.addProperty().setCode("kind").setValue(new CodeType(getClassKindName(c.getKind())));
+               } else {
+                    log.warn("Unrecognised class kind on class " + c.getCode() + ": " + c.getKind());
+                }
+            } else if (excludeKindlessClasses) {
+                log.info("Concept " + c.getCode() + " has excluded kind " + getClassKindName(c.getKind()) + ": skipping");
+                continue;
+            } else {
+                log.info("Concept " + c.getCode() + " has no kind.");
+            }
+            for (SubClass sub : c.getSubClass()) {
+                concept.addProperty().setCode("child").setValue(new CodeType(sub.getCode()));
+                descendents.get(c.getCode()).add(sub.getCode());
+                if (descendents.containsKey(sub.getCode()) && !descendents.get(sub.getCode()).isEmpty()) {
+                    descendents.get(c.getCode()).addAll(descendents.get(sub.getCode()));
+                }
+            }
+            for (SuperClass sup : c.getSuperClass()) {
+                concept.addProperty().setCode("parent").setValue(new CodeType(sup.getCode()));
+                if (!descendents.containsKey(sup.getCode())) {
+                    descendents.put(sup.getCode(), new HashSet<>());
+                }
+                descendents.get(sup.getCode()).add(c.getCode());
+                if (!descendents.get(c.getCode()).isEmpty()) {
+                    descendents.get(sup.getCode()).addAll(descendents.get(c.getCode()));
+                }
+            }
+            Map<String,List<Rubric>> displayRubricValues = new HashMap<>();
+            for (Rubric rubric : c.getRubric()) {
+                Object kind = rubric.getKind();
+                if (kind instanceof RubricKind) {
+                    RubricKind rkind = (RubricKind) kind;
+                    if (displayRubrics.contains(rkind.getName())) {
+                        final String value;
+                        if (rubric.getLabel().size() > 1) {
+                            log.warn("Found more than one label on display rubric " + rkind.getName() + " for code " + c.getCode());
+                        }
+                        value = getLabelValue(rubric.getLabel().get(0));
+                        if (!displayRubricValues.containsKey(rkind.getName())) {
+                        	displayRubricValues.put(rkind.getName(), new ArrayList<>());
+                        }
+                        displayRubricValues.get(rkind.getName()).add(rubric);
+                    } else if (rkind.getName().equals(definitionRubric)) {
+                            final String value;
+                            if (rubric.getLabel().size() > 1) {
+                                log.warn("Found more than one label on definition rubric for code " + c.getCode());
+                            }
+                            value = getLabelValue(rubric.getLabel().get(0));
+                            concept.setDefinition(value);
+
+                    } else if (designationRubrics.contains(rkind.getName())) {
+                        addDesignationsForRubric(concept, rubric);
+                    } else {
+                        for (Label l : rubric.getLabel()) {
+                            String v = getLabelValue(l);
+                            if (v != null && v.length() > 0) {
+                                ConceptPropertyComponent prop = concept.addProperty();
+                                prop.setCode(rkind.getName());
+                                prop.setValue(new StringType(v));
+                            }
+                        }
+                    }
+                } else {
+                    log.warn("Unexpected rubric kind " + kind);
+                }
+            }
+            
+            for (String dr : displayRubrics) {
+            	if (!displayRubricValues.containsKey(dr)) {
+            		continue;
+            	}
+        		List<Rubric> values = displayRubricValues.get(dr);
+            	if (!concept.hasDisplay()) {
+            		if (values.size() > 1) {
+            			log.warn("Found multiple display rubrics " + dr + " for code " + c.getCode());
+            		}
+            		Rubric rubric = values.get(0);
+                    String value = getLabelValue(rubric.getLabel().get(0));
+
+            		concept.setDisplay(value);
+            		if (rubric.getLabel().size() > 1) {
+            			if (log.isWarnEnabled()) {
+                            log.warn("Found more than one label on display rubric " + dr + " for code " + c.getCode());
+            			}
+            			for (int i = 1; i < values.size(); i++) {
+            				addDesignationForLabel(concept, rubric, (RubricKind) rubric.getKind(), rubric.getLabel().get(i));
+            			}
+            		}
+            	} else {
+            		// We've already got a display, dump everything else as a designation
+            		for (Rubric r : values) {
+            			addDesignationsForRubric(concept, r);
+            		}
+            	}
+            }
+
+            if (!concept.hasCode()) {
+                log.warn("Concept " + concept + " has no code!");
+            } else {
+                if (!concept.hasDisplay()) {
+                    log.warn("Concept " + concept.getCode() + " has no display text. Using code as display text");
+                    concept.setDisplay(concept.getCode());
+                    if (!concept.hasDefinition()) {
+                        concept.setDefinition(concept.getCode());
+                    }
+                } else if (!concept.hasDefinition()) {
+                    concept.setDefinition(concept.getDisplay());
+                }
+            }
+            
+            if (!c.getModifiedBy().isEmpty()) {
+                if (!modifiedBy.containsKey(c.getCode())) {
+                    modifiedBy.put(c.getCode(), new ArrayList<>());
+                }
+                if (log.isDebugEnabled()) {
+                    log.debug("Adding " + c.getModifiedBy().size() + " modifiers to class " + c.getCode());
+                }
+                modifiedBy.get(c.getCode()).addAll(c.getModifiedBy());
+            }
+        }
+        
+        Map <String,Set<ModifierClass>> modifierClasses = new HashMap<>();
+        for (ModifierClass modClass : claml.getModifierClass()) {
+            if (!modifierClasses.containsKey(modClass.getModifier())) {
+                modifierClasses.put(modClass.getModifier(), new HashSet<>());
+            }
+            modifierClasses.get(modClass.getModifier()).add(modClass);
+        }
+        
+        for (String modifiedConcept : modifiedBy.keySet()) {
+            List<ConceptDefinitionComponent> candidates = new ArrayList<>();
+            candidates.add(concepts.get(modifiedConcept));
+            //Apply the modifiers in order to the modified concept
+            List<ConceptDefinitionComponent> newCandidates = null;
+            for (ModifiedBy modBy : modifiedBy.get(modifiedConcept)) {
+
+                // for each candidate
+                newCandidates = new ArrayList<>();
+                candidates: for (ConceptDefinitionComponent cand : candidates) {
+                    log.info("Applying modifier " + modBy.getCode() + " to " + cand.getCode());
+
+                    // for each applicable ModifierClass
+                    for (ModifierClass modClass : modifierClasses.get(modBy.getCode())) {
+                        // If ModifiedBy.all == false and there is no ModifiedBy.ValidModifierClass for this modifier class, then skip it
+                        if (!modBy.isAll() && !modBy.getValidModifierClass().stream().anyMatch(vmc -> vmc.getCode().equals(modClass.getCode()))) {
+                            log.info("Skipping modifierClass " + modClass.getCode() + " due to missing ValidModifierClass on class " + cand.getCode());
+
+                            continue candidates;
+                        }
+                        for ( Meta excl : modClass.getMeta().stream().filter(met -> met.getName().equals("excludeOnPrecedingModifier") ).collect(Collectors.toList())) {
+                            String[] substrings = excl.getValue().split(" ");
+                            log.info("Found excludeOnPrecedingModifier " + excl.getValue());
+                            if (substrings.length == 2 && cand.getCode().endsWith(substrings[1])) {
+                                log.info("Skipping modifierClass " + modClass.getCode() + " due to excludeOnPrecedingModifier on class " + cand.getCode());
+                                continue candidates;
+                            }
+                        }
+                        ConceptDefinitionComponent concept = cs.addConcept();
+                        count++;
+                        newCandidates.add(concept);
+                        //Set code to append modifierClass code
+                        concept.setCode(cand.getCode() + modClass.getCode());
+                        Map<String,List<Rubric>> displayRubricValues = new HashMap<>();
+                        //Fix display to append modifierClass display
+                        for (Rubric rubric : modClass.getRubric()) {
+                            Object kind = rubric.getKind();
+                            if (kind instanceof RubricKind) {
+                                RubricKind rkind = (RubricKind) kind;
+                                if (displayRubrics.contains(rkind.getName())) {
+                                    if (rubric.getLabel().size() > 1) {
+                                        log.warn("Found more than one label on display rubric " + rkind.getName() + " for code " + modClass.getCode());
+                                    }
+                                    if (!displayRubricValues.containsKey(rkind.getName())) {
+                                        displayRubricValues.put(rkind.getName(), new ArrayList<>());
+                                    }
+                                    displayRubricValues.get(rkind.getName()).add(rubric);
+                                }
+                            }
+                        }
+                        for (String dr : displayRubrics) {
+                            if (!displayRubricValues.containsKey(dr)) {
+                                continue;
+                            }
+                            List<Rubric> values = displayRubricValues.get(dr);
+                            if (values.size() > 1) {
+                                log.warn("Found multiple display rubrics " + dr + " for modifierClass " + modClass.getCode());
+                            }
+                            Rubric rubric = values.get(0);
+                            String value = getLabelValue(rubric.getLabel().get(0));
+
+                            concept.setDisplay(cand.getDisplay() + " : " + value);
+                            if (rubric.getLabel().size() > 1) {
+                                if (log.isWarnEnabled()) {
+                                    log.warn("Found more than one label on display rubric " + dr + " for code " + modClass.getCode());
+                                }
+                            }
+                        }
+                        // Remove old parent/child links
+//                            concept.getProperty().removeIf(p -> p.getCode().equals("parent") || p.getCode().equals("child"));
+                        concept.addProperty().setCode("parent").setValue(new CodeType(cand.getCode()));
+                    }
+                }
+                candidates = newCandidates;
+
+            }
+            
+            //TODO Apply to all descendents of the concept
+            //TODO Consider ExcludeModifier elements
+        }
+        
+
+        cs.setCount(count);
+        return cs;
     }
 
 	private void addDesignationsForRubric(ConceptDefinitionComponent concept, Rubric rubric) {

--- a/src/test/java/au/csiro/fhir/claml/ModifierTest.java
+++ b/src/test/java/au/csiro/fhir/claml/ModifierTest.java
@@ -63,6 +63,12 @@ public class ModifierTest {
         missingCodes.removeAll(codes);
         assertTrue("Missing codes " + missingCodes.stream().collect(Collectors.joining(",")), codes.containsAll(Arrays.asList(expectedCodes)));
         assertEquals(expectedCodes.length, codes.size());
+        
+        assertEquals("chapter D : Modification 2 : Nodification 1", cs.getConcept().stream().filter(cdc -> cdc.getCode().equals("DM2N1")).findFirst().get().getDisplay());
+        assertEquals(1, cs.getConcept().stream().filter(c -> c.getCode().equals("DM2N1")).findAny().get().getProperty().stream().filter(p->p.getCode().equals("parent")).count());
+        assertEquals("DM2", cs.getConcept().stream().filter(c -> c.getCode().equals("DM2N1")).findAny().get().getProperty().stream().filter(p->p.getCode().equals("parent")).findAny().get().getValueCodeType().getCode());
+        assertEquals("D", cs.getConcept().stream().filter(c -> c.getCode().equals("DM2")).findAny().get().getProperty().stream().filter(p->p.getCode().equals("parent")).findAny().get().getValueCodeType().getCode());
+
     }
 
 }

--- a/src/test/java/au/csiro/fhir/claml/ModifierTest.java
+++ b/src/test/java/au/csiro/fhir/claml/ModifierTest.java
@@ -1,0 +1,68 @@
+package au.csiro.fhir.claml;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.io.FileReader;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import javax.xml.bind.JAXBContext;
+import javax.xml.bind.JAXBException;
+import javax.xml.bind.Unmarshaller;
+import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.parsers.SAXParserFactory;
+import javax.xml.transform.sax.SAXSource;
+
+import org.hl7.fhir.r4.model.CodeSystem;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.springframework.core.io.ClassPathResource;
+import org.xml.sax.InputSource;
+import org.xml.sax.SAXException;
+import org.xml.sax.XMLReader;
+
+import au.csiro.fhir.claml.model.claml.ClaML;
+
+public class ModifierTest {
+
+    private static FhirClamlService controller;
+    private static JAXBContext jaxbContext;
+
+    @BeforeClass
+    public static void init() throws JAXBException {
+        controller = new FhirClamlService();
+        jaxbContext = JAXBContext.newInstance(ClaML.class);
+    }
+
+    @Test
+    public void testTransform() throws ParserConfigurationException, SAXException, JAXBException, IOException {
+        SAXParserFactory spf = SAXParserFactory.newInstance();
+        spf.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
+        spf.setFeature("http://xml.org/sax/features/validation", false);
+
+        XMLReader xmlReader = spf.newSAXParser().getXMLReader();
+        InputSource inputSource = new InputSource(
+                new FileReader(new ClassPathResource("modifiers-test.xml").getFile()));
+        SAXSource source = new SAXSource(xmlReader, inputSource);
+        Unmarshaller jaxbUnmarshaller = jaxbContext.createUnmarshaller();
+        ClaML claml = (ClaML) jaxbUnmarshaller.unmarshal(source);
+
+        CodeSystem cs = controller.claml2FhirObject(claml, Collections.emptyList(), null, Collections.emptyList(), Collections.emptyList(), false, null, null, null, null, null, false);
+        Set<String> codes = cs.getConcept().stream().map(c -> c.getCode()).collect(Collectors.toSet());
+
+        String[] expectedCodes = {"A", "A.1", "A.2", "A.3", "B", "C", "D", "BM1", "BM2", "CM1", "DM1", "DM1N1", "DM2", "DM2N1", "DM2N2" };
+        
+        List<String> expectedCodesList = Arrays.asList(expectedCodes);
+        List<String> missingCodes = new ArrayList<>(expectedCodesList);
+        missingCodes.removeAll(codes);
+        assertTrue("Missing codes " + missingCodes.stream().collect(Collectors.joining(",")), codes.containsAll(Arrays.asList(expectedCodes)));
+        assertEquals(expectedCodes.length, codes.size());
+    }
+
+}

--- a/src/test/resources/modifiers-test.xml
+++ b/src/test/resources/modifiers-test.xml
@@ -1,13 +1,12 @@
 <?xml version="1.0"?>
-<!DOCTYPE ClaML SYSTEM "http://terminologies.eu/download/en14463-2007.dtd">
 <ClaML version="2.0.0">
 	<Title name="example" date="20070926" version="1">Example ClaML</Title>
 	<ClassKinds>
-		<Kind name="category"/>
-		<Kind name="chapter"/>
+		<ClassKind name="category"/>
+		<ClassKind name="chapter"/>
 	</ClassKinds>
 	<RubricKinds>
-		<Kind name="preferred"/>
+		<RubricKind name="preferred"/>
 	</RubricKinds>
 	<Modifier code="M">
 	    <SubClass code="M1"/>
@@ -35,6 +34,7 @@
         </Rubric>
     </ModifierClass>
     <ModifierClass code="N2" modifier="N">
+    <SuperClass code="N"/>
         <Meta name="excludeOnPrecedingModifier" value="M M1"/>    
         <Rubric kind="preferred">
             <Label xml:lang="en">Nodification 2</Label>
@@ -66,7 +66,7 @@
         <ModifiedBy code="M"/>
         <ModifiedBy code="N"/>
         <Rubric kind="preferred">
-            <Label xml:lang="en">chapter C</Label>
+            <Label xml:lang="en">chapter D</Label>
         </Rubric>
     </Class>
 	<Class code="A.1" kind="category">

--- a/src/test/resources/modifiers-test.xml
+++ b/src/test/resources/modifiers-test.xml
@@ -1,0 +1,90 @@
+<?xml version="1.0"?>
+<!DOCTYPE ClaML SYSTEM "http://terminologies.eu/download/en14463-2007.dtd">
+<ClaML version="2.0.0">
+	<Title name="example" date="20070926" version="1">Example ClaML</Title>
+	<ClassKinds>
+		<Kind name="category"/>
+		<Kind name="chapter"/>
+	</ClassKinds>
+	<RubricKinds>
+		<Kind name="preferred"/>
+	</RubricKinds>
+	<Modifier code="M">
+	    <SubClass code="M1"/>
+	    <SubClass code="M2"/>
+	</Modifier>
+	<ModifierClass code="M1" modifier="M">
+	    <SuperClass code="M"/>
+		<Rubric kind="preferred">
+			<Label xml:lang="en">Modification 1</Label>
+		</Rubric>
+	</ModifierClass>
+    <ModifierClass code="M2" modifier="M">
+        <Rubric kind="preferred">
+            <Label xml:lang="en">Modification 2</Label>
+        </Rubric>
+    </ModifierClass>
+    <Modifier code="N">
+        <SubClass code="N1"/>
+        <SubClass code="N2"/>
+    </Modifier>
+    <ModifierClass code="N1" modifier="N">
+        <SuperClass code="N"/>
+        <Rubric kind="preferred">
+            <Label xml:lang="en">Nodification 1</Label>
+        </Rubric>
+    </ModifierClass>
+    <ModifierClass code="N2" modifier="N">
+        <Meta name="excludeOnPrecedingModifier" value="M M1"/>    
+        <Rubric kind="preferred">
+            <Label xml:lang="en">Nodification 2</Label>
+        </Rubric>
+    </ModifierClass>
+	<Class code="A" kind="chapter">
+		<SubClass code="A.1" />
+		<SubClass code="A.2" />
+		<SubClass code="A.3"/>
+		<Rubric kind="preferred">
+			<Label xml:lang="en">chapter A</Label>
+		</Rubric>
+	</Class>
+	<Class code="B" kind="chapter">
+	    <ModifiedBy all="true" code="M"/>
+		<Rubric kind="preferred">
+			<Label xml:lang="en">chapter B</Label>
+		</Rubric>
+	</Class>
+	<Class code="C" kind="chapter">
+		<ModifiedBy all="false" code="M">
+			<ValidModifierClass code="M1" />
+		</ModifiedBy>
+		<Rubric kind="preferred">
+			<Label xml:lang="en">chapter C</Label>
+		</Rubric>
+	</Class>
+    <Class code="D" kind="chapter">
+        <ModifiedBy code="M"/>
+        <ModifiedBy code="N"/>
+        <Rubric kind="preferred">
+            <Label xml:lang="en">chapter C</Label>
+        </Rubric>
+    </Class>
+	<Class code="A.1" kind="category">
+		<SuperClass code="A"/>
+		<Rubric kind="preferred">
+			<Label xml:lang="en">example class</Label>
+		</Rubric>
+	</Class>
+	<Class code="A.2" kind="category">
+		<SuperClass code="A"/>
+		<Rubric kind="preferred">
+			<Label xml:lang="en">example class</Label>
+		</Rubric>
+	</Class>
+	<Class code="A.3" kind="category">
+		<SuperClass code="A"/>
+		<Rubric kind="preferred">
+			<Label xml:lang="en">example class</Label>
+		</Rubric>
+	</Class>
+</ClaML>


### PR DESCRIPTION
Adding support for Modifiers. Concepts that are generated from Modifiers get a code (parent code concatenated with the modifierClass code), and display (parent display concatenated with modifier class display separated by a colon), but do not get other designation/definition/property rubrics. It also doesn't handle inherited ModifiedBy statements.