### PR TITLE
fix missing valueset in output

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ The following options are available:
 | -id                      | string      | The technical id of the code system. Required if using PUT to upload the resource to a FHIR server. |
 | -o                       | string      | The output FHIR JSON file. |
 | -url                     | string      | Canonical identifier of the code system. |
-| -valueset                | string      | The value set that represents the entire code system. |
+| -valueSet                | string      | The value set that represents the entire code system. |
 | -versionNeeded           | none        | Flag to indicate if the code system commits to concept permanence across versions. |
 
 ### Examples

--- a/src/main/java/au/csiro/fhir/claml/Application.java
+++ b/src/main/java/au/csiro/fhir/claml/Application.java
@@ -120,7 +120,7 @@ public class Application implements CommandLineRunner {
 
         options.addOption("url", true, "Canonical identifier of the code system.");
 
-        options.addOption("valueset", true, "The value set that represents the entire code system.");
+        options.addOption("valueSet", true, "The value set that represents the entire code system.");
 
         options.addOption("versionNeeded", false, "Flag to indicate if the code system commits "
                 + "to concept permanence across versions.");


### PR DESCRIPTION
The `valueset` parameter is not actually used in the output routine due to a discrepancy in the name of the command-line parameter (`valueset`) and the value that is provided to the converter (`valueSet`). For consistency, I'd propose the use of the command-line parameter `valueSet` with capital `S`, since this is closer to the FHIR spec, and other parameters are also written in camelCase.