### PR TITLE
customisable title and identifiers

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,8 +32,10 @@ The following options are available:
 | -help                    | none        | Print the help message. |
 | -hierarchyMeaning        | string      | The hierarchyMeaning of the code system. Allowable values are 'is-a', 'part-of', 'grouped-by', and 'classified-with'. Default is 'is-a'. |
 | -i                       | string      | The input ClaML file. |
+| -identifier              | string      | Comma-separated list of additional business identifiers. Each business identifer has the format <code>\[system\]&#124;\[value\]</code>.|
 | -id                      | string      | The technical id of the code system. Required if using PUT to upload the resource to a FHIR server. |
 | -o                       | string      | The output FHIR JSON file. |
+| -t                       | string      | The title to use for the resultant CodeSystem, defaults to the calculated value for name if not provided |
 | -url                     | string      | Canonical identifier of the code system. |
 | -valueSet                | string      | The value set that represents the entire code system. |
 | -versionNeeded           | none        | Flag to indicate if the code system commits to concept permanence across versions. |

--- a/pom.xml
+++ b/pom.xml
@@ -51,14 +51,14 @@
 		<dependency>
             <groupId>ca.uhn.hapi.fhir</groupId>
             <artifactId>hapi-fhir-client</artifactId>
-            <version>4.2.0</version>
+            <version>5.7.2</version>
         </dependency>
         <dependency>
             <groupId>ca.uhn.hapi.fhir</groupId>
             <artifactId>hapi-fhir-structures-r4</artifactId>
-            <version>4.2.0</version>
+            <version>5.7.2</version>
         </dependency>
-		<dependency>
+		    <dependency>
             <groupId>javax.xml.bind</groupId>
             <artifactId>jaxb-api</artifactId>
             </dependency>
@@ -75,7 +75,13 @@
         <dependency>
             <groupId>commons-cli</groupId>
             <artifactId>commons-cli</artifactId>
-            <version>1.4</version>
+            <version>1.5.0</version>
+        </dependency>
+
+        <dependency>
+          <groupId>org.junit.jupiter</groupId>
+          <artifactId>junit-jupiter-api</artifactId>
+          <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.hamcrest</groupId>

--- a/src/main/java/au/csiro/fhir/claml/Application.java
+++ b/src/main/java/au/csiro/fhir/claml/Application.java
@@ -127,6 +127,11 @@ public class Application implements CommandLineRunner {
         options.addOption("versionNeeded", false, "Flag to indicate if the code system commits "
                 + "to concept permanence across versions.");
 
+        options.addOption("identifier", true, "Comma-separated list of additional business "
+            + "identifiers. Each business identifer has the format [system]|[value].");
+
+        options.addOption("t", "title", true, "A human-friendly name for the code system.");
+
         // The following options are not yet supported
         /*
 
@@ -146,8 +151,6 @@ public class Application implements CommandLineRunner {
 	    options.addOption("experimental", false, "Indicates if the code system is for testing "
 	        + "purposes or real usage.");
 
-	    options.addOption("identifier", true, "Comma-separated list of additional business "
-	        + "identifiers. Each business identifer has the format [system]|[value].");
 
 	    options.addOption("language", true, "The language of the generated code system. This is a code from the "
 	        + "FHIR Common Languages value set.");
@@ -161,8 +164,6 @@ public class Application implements CommandLineRunner {
 
 	    options.addOption("status", true, "Code system status. Valid values are draft, active, "
 	        + "retired and unknown");
-
-	    options.addOption("t", "title", true, "A human-friendly name for the code system.");
 
 	    options.addOption("v", "version", true, "Business version. If this option is not specified "
 	        + "then the ClaML title.version attribute value will be used.");
@@ -196,6 +197,8 @@ public class Application implements CommandLineRunner {
                         line.getOptionValue("content"),
                         line.hasOption("versionNeeded"),
                         Boolean.parseBoolean(line.getOptionValue("applyModifiers")),
+                        line.getOptionValue("identifier"),
+                        line.getOptionValue("t"),
                         new File(line.getOptionValue("output")));
             } catch (Throwable t) {
                 System.out.println("There was a problem transforming the ClaML file into FHIR: " 

--- a/src/test/java/au/csiro/fhir/claml/FhirClamlTest.java
+++ b/src/test/java/au/csiro/fhir/claml/FhirClamlTest.java
@@ -1,6 +1,6 @@
 package au.csiro.fhir.claml;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class FhirClamlTest {
 

--- a/src/test/java/au/csiro/fhir/claml/ModifierTest.java
+++ b/src/test/java/au/csiro/fhir/claml/ModifierTest.java
@@ -1,7 +1,8 @@
 package au.csiro.fhir.claml;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.FileReader;
 import java.io.IOException;
@@ -20,8 +21,8 @@ import javax.xml.parsers.SAXParserFactory;
 import javax.xml.transform.sax.SAXSource;
 
 import org.hl7.fhir.r4.model.CodeSystem;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import org.springframework.core.io.ClassPathResource;
 import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
@@ -34,7 +35,7 @@ public class ModifierTest {
     private static FhirClamlService controller;
     private static JAXBContext jaxbContext;
 
-    @BeforeClass
+    @BeforeAll
     public static void init() throws JAXBException {
         controller = new FhirClamlService();
         jaxbContext = JAXBContext.newInstance(ClaML.class);
@@ -53,7 +54,7 @@ public class ModifierTest {
         Unmarshaller jaxbUnmarshaller = jaxbContext.createUnmarshaller();
         ClaML claml = (ClaML) jaxbUnmarshaller.unmarshal(source);
 
-        CodeSystem cs = controller.claml2FhirObject(claml, Collections.emptyList(), null, Collections.emptyList(), Collections.emptyList(), false, null, null, null, null, null, false, true);
+        CodeSystem cs = controller.claml2FhirObject(claml, Collections.emptyList(), null, Collections.emptyList(), Collections.emptyList(), false, null, null, null, null, null, false, true, null, null);
         Set<String> codes = cs.getConcept().stream().map(c -> c.getCode()).collect(Collectors.toSet());
 
         String[] expectedCodes = {"A", "A.1", "A.2", "A.3", "B", "C", "D", "BM1", "BM2", "CM1", "DM1", "DM1N1", "DM2", "DM2N1", "DM2N2" };
@@ -61,7 +62,7 @@ public class ModifierTest {
         List<String> expectedCodesList = Arrays.asList(expectedCodes);
         List<String> missingCodes = new ArrayList<>(expectedCodesList);
         missingCodes.removeAll(codes);
-        assertTrue("Missing codes " + missingCodes.stream().collect(Collectors.joining(",")), codes.containsAll(Arrays.asList(expectedCodes)));
+        assertTrue(codes.containsAll(Arrays.asList(expectedCodes)), "Missing codes " + missingCodes.stream().collect(Collectors.joining(",")));
         assertEquals(expectedCodes.length, codes.size());
         
         assertEquals("chapter D : Modification 2 : Nodification 1", cs.getConcept().stream().filter(cdc -> cdc.getCode().equals("DM2N1")).findFirst().get().getDisplay());


### PR DESCRIPTION
This change updates dependencies for HAPI to support multiple identifiers for the CodeSystem as well as adding input parameters to specify business identifiers and customise the title of the generated resource.